### PR TITLE
Improve context error handling and hook deps

### DIFF
--- a/src/contexts/Web3Context.tsx
+++ b/src/contexts/Web3Context.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import React, { createContext, useContext, useMemo } from "react";
 import { ethers } from "ethers";
 


### PR DESCRIPTION
## Summary
- add defensive error handling and response validation to AIContext's `ask`
- clean up StorageContext hook dependencies and remove unused provider
- require signer for KV operations and silence unnecessary React Refresh warnings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: "spawn" is not exported by "__vite-browser-external")*

------
https://chatgpt.com/codex/tasks/task_e_68b771367ff8832e8918b1f31a9c2b54